### PR TITLE
Fix Clippy warnings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.51.0  # MSRV
+          # - 1.51.0  # MSRV
           - nightly # For checking minimum version dependencies.
 
     steps:

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,6 @@
 use std::convert::TryInto;
 
-#[cfg(any(feature = "sync"))]
+#[cfg(feature = "sync")]
 pub(crate) mod concurrent;
 
 pub(crate) mod builder_utils;

--- a/src/common/deque.rs
+++ b/src/common/deque.rs
@@ -108,7 +108,7 @@ impl<T> Deque<T> {
             head: None,
             tail: None,
             cursor: None,
-            marker: PhantomData::default(),
+            marker: PhantomData,
         }
     }
 


### PR DESCRIPTION
- Fix Clippy warnings.
- Temporarily disable CI for the MSRV 1.51.