### PR TITLE
Bump the Minimum Supported Rust Version (MSRV) to 1.61

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
         rust:
           - stable
           - beta
-          # - 1.51.0  # MSRV
+          - 1.61.0  # MSRV
           - nightly # For checking minimum version dependencies.
 
     steps:
@@ -52,15 +52,10 @@ jobs:
           command: update
           args: -Z minimal-versions
 
-      - name: Pin some dependencies to specific versions (MSRV only)
-        if: ${{ matrix.rust == '1.51.0' }}
-        # hashbrown >= v0.12 requires Rust 2021 edition.
-        # pull-down-cmark >= 0.9.2 requires Rust 2021 edition.
-        # once_cell >= 1.15.0 requires Rust 2021 edition.
-        run: |
-          cargo update -p dashmap --precise 5.2.0
-          cargo update -p pulldown-cmark --precise 0.9.1
-          cargo update -p once_cell --precise 1.14.0
+      # - name: Pin some dependencies to specific versions (MSRV only)
+      #   if: ${{ matrix.rust == '1.61.0' }}
+      #   run: |
+      #     cargo update -p dashmap --precise 5.2.0
 
       - name: Show cargo tree
         uses: actions-rs/cargo@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Mini Moka Cache &mdash; Change Log
 
+## Version 0.10.1 (Unreleased)
+
+Bumped the minimum supported Rust version (MSRV) to 1.61 (May 19, 2022).
+([#5][gh-pull-0005])
+
+
 ## Version 0.10.0
 
 In this version, we removed some dependencies from Mini Moka to make it more
@@ -34,5 +40,6 @@ lightweight.
 <!-- Links -->
 [moka-v0.9.6]: https://github.com/moka-rs/moka/tree/v0.9.6
 
+[gh-pull-0005]: https://github.com/moka-rs/mini-moka/pull/5/
 [gh-pull-0002]: https://github.com/moka-rs/mini-moka/pull/2/
 [gh-pull-0001]: https://github.com/moka-rs/mini-moka/pull/1/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "mini-moka"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2018"
-rust-version = "1.51"
+rust-version = "1.61"
 
 description = "A lighter edition of Moka, a fast and concurrent cache library"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -268,9 +268,9 @@ key expiration.
 
 Mini Moka's minimum supported Rust versions (MSRV) are the followings:
 
-| Feature          | MSRV                     |
-|:-----------------|:------------------------:|
-| default features | Rust 1.51.0 (2021-03-25) |
+| Feature          | MSRV                       |
+|:-----------------|:--------------------------:|
+| default features | Rust 1.61.0 (May 19, 2022) |
 
 It will keep a rolling MSRV policy of at least 6 months. If only the default features
 are enabled, MSRV will be updated conservatively. When using other features, MSRV

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(rust_2018_idioms)]
-// Temporary disable this lint as the MSRV (1.51) require an older lint name:
-// #![deny(rustdoc::broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Mini Moka is a fast, concurrent cache library for Rust. Mini Moka is a light
@@ -50,9 +49,9 @@
 //!
 //! This crate's minimum supported Rust versions (MSRV) are the followings:
 //!
-//! | Feature    | Enabled by default? | MSRV        |
-//! |:-----------|:-------------------:|:-----------:|
-//! | no feature |                     | Rust 1.51.0 |
+//! | Feature          | MSRV                       |
+//! |:-----------------|:--------------------------:|
+//! | default features | Rust 1.61.0 (May 19, 2022) |
 //!
 //! If only the default features are enabled, MSRV will be updated conservatively.
 //! When using other features, MSRV might be updated more frequently, up to the


### PR DESCRIPTION
Bump the MSRV from 1.51 (Mar 25, 2021) to 1.61 (May 19, 2022).

The following dependencies do not compile with 1.51:
- `dashmap` v5.3.0, which depends on `hashbrown` >= v0.12.0
- `once_cell` v1.15.0
- `syn` v2.0.18
