### PR TITLE
Fix Cilppy warnings and MSRV CI

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eux
+
+# Pin some dependencies to specific versions for the MSRV.
+cargo update -p dashmap --precise 5.4.0
+cargo update -p tempfile --precise 3.6.0

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,10 +52,9 @@ jobs:
           command: update
           args: -Z minimal-versions
 
-      # - name: Pin some dependencies to specific versions (MSRV only)
-      #   if: ${{ matrix.rust == '1.61.0' }}
-      #   run: |
-      #     cargo update -p dashmap --precise 5.2.0
+      - name: Pin some dependencies to specific versions (MSRV only)
+        if: ${{ matrix.rust == '1.61.0' }}
+        run: ./.ci_extras/pin-crate-vers-msrv.sh
 
       - name: Show cargo tree
         uses: actions-rs/cargo@v1

--- a/.github/workflows/Lints.yml
+++ b/.github/workflows/Lints.yml
@@ -16,8 +16,9 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
-          - beta
+          - toolchain: stable
+          - toolchain: beta
+            rustflags: '--cfg beta_clippy'
 
     steps:
       - name: Checkout Moka
@@ -27,7 +28,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: ${{ matrix.rust.toolchain }}
           override: true
           components: rustfmt, clippy
 
@@ -40,14 +41,15 @@ jobs:
 
       - name: Run Clippy
         uses: actions-rs/clippy-check@v1
-        if: ${{ matrix.rust == 'stable' || matrix.rust == 'beta' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --lib --tests --all-features --all-targets -- -D warnings
+        env:
+          RUSTFLAGS: ${{ matrix.rust.rustflags }}
 
       - name: Run Rustfmt
         uses: actions-rs/cargo@v1
-        if: ${{ matrix.rust == 'stable' }}
+        if: ${{ matrix.rust.toolchain == 'stable' }}
         with:
           command: fmt
           args: --all -- --check

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -252,7 +252,7 @@ mod tests {
         let mut sketch = FrequencySketch::default();
         sketch.ensure_capacity(512);
         let mut indexes = std::collections::HashSet::new();
-        let hashes = vec![std::u64::MAX, 0, 1];
+        let hashes = [std::u64::MAX, 0, 1];
         for hash in hashes.iter() {
             for depth in 0..4 {
                 indexes.insert(sketch.index_of(*hash, depth));

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -97,7 +97,8 @@ where
     ) -> Self {
         let (r_snd, r_rcv) = crossbeam_channel::bounded(READ_LOG_SIZE);
         let (w_snd, w_rcv) = crossbeam_channel::bounded(WRITE_LOG_SIZE);
-        let inner = Arc::new(Inner::new(
+
+        let inner = Inner::new(
             max_capacity,
             initial_capacity,
             build_hasher,
@@ -106,13 +107,13 @@ where
             w_rcv,
             time_to_live,
             time_to_idle,
-        ));
-        let housekeeper = Housekeeper::default();
+        );
         Self {
-            inner,
+            #[cfg_attr(beta_clippy, allow(clippy::arc_with_non_send_sync))]
+            inner: Arc::new(inner),
             read_op_ch: r_snd,
             write_op_ch: w_snd,
-            housekeeper: Some(Arc::new(housekeeper)),
+            housekeeper: Some(Arc::new(Housekeeper::default())),
         }
     }
 


### PR DESCRIPTION
## Fix Clippy warnings

- clippy 0.1.72 (a47f796a365 2023-07-22)
- Add a cfg flag called `clippy_beta` to allow a lint when Clippy beta is used.
    - This is needed because the same lint is not available in Clippy stable.

## Fix CI for the MSRV

When testing the MSRV (1.60.0) of `moka` 0.10.x, downgrade the following crates, so they will compile:

- Downgrade `dashmap` to v5.4.0
- Downgrade `tempfile` to v3.6.0.
