### PR TITLE
Add upsert

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ default = ["sync"]
 
 sync = ["dashmap"]
 
+testing = []
+
 [dependencies]
 crossbeam-channel = "0.5.5"
 crossbeam-utils = "0.8"

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,7 +6,7 @@ pub(crate) mod concurrent;
 pub(crate) mod builder_utils;
 pub(crate) mod deque;
 pub(crate) mod frequency_sketch;
-pub(crate) mod time;
+pub mod time;
 
 // Note: `CacheRegion` cannot have more than four enum variants. This is because
 // `crate::{sync,unsync}::DeqNodes` uses a `tagptr::TagNonNull<DeqNode<T>, 2>`

--- a/src/common/time.rs
+++ b/src/common/time.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
-pub(crate) mod clock;
+pub mod clock;
 
-pub(crate) use clock::Clock;
+pub use clock::Clock;
 
 /// a wrapper type over Instant to force checked additions and prevent
 /// unintentional overflow. The type preserve the Copy semantics for the wrapped

--- a/src/common/time/clock.rs
+++ b/src/common/time/clock.rs
@@ -3,18 +3,18 @@ use std::{
     time::Instant as StdInstant,
 };
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 use std::time::Duration;
 
 pub(crate) type Instant = StdInstant;
 
-pub(crate) struct Clock {
+pub struct Clock {
     mock: Option<Arc<Mock>>,
 }
 
 impl Clock {
-    #[cfg(test)]
-    pub(crate) fn mock() -> (Clock, Arc<Mock>) {
+    #[cfg(any(test, feature = "testing"))]
+    pub fn mock() -> (Clock, Arc<Mock>) {
         let mock = Arc::new(Mock::default());
         let clock = Clock {
             mock: Some(Arc::clone(&mock)),
@@ -31,6 +31,12 @@ impl Clock {
     }
 }
 
+#[cfg(any(test, feature = "testing"))]
+pub struct Mock {
+    now: RwLock<Instant>,
+}
+
+#[cfg(not(any(test, feature = "testing")))]
 pub(crate) struct Mock {
     now: RwLock<Instant>,
 }
@@ -43,9 +49,9 @@ impl Default for Mock {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 impl Mock {
-    pub(crate) fn increment(&self, amount: Duration) {
+    pub fn increment(&self, amount: Duration) {
         *self.now.write().expect("lock poisoned") += amount;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 //! latest stable. In both cases, increasing MSRV is _not_ considered a
 //! semver-breaking change.
 
-pub(crate) mod common;
+pub mod common;
 pub(crate) mod policy;
 pub mod unsync;
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -14,8 +14,19 @@ pub use cache::Cache;
 pub use iter::Iter;
 pub use mapref::EntryRef;
 
+use std::sync::Arc;
+
 /// Provides extra methods that will be useful for testing.
 pub trait ConcurrentCacheExt<K, V> {
     /// Performs any pending maintenance operations needed by the cache.
     fn sync(&self);
+}
+
+/// Allows users to implement their own EvictionHandler
+pub trait EvictionHandler<K, V>
+where
+    K: Send + Sync,
+    V: Send + Sync,
+{
+    fn on_remove(&self, _: Arc<K>, _: &V) {}
 }

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -391,8 +391,16 @@ where
         // Enable the frequency sketch.
         self.inner.enable_frequency_sketch_for_testing();
     }
+}
 
-    pub(crate) fn set_expiration_clock(&self, clock: Option<Clock>) {
+#[cfg(any(test, feature = "testing"))]
+impl<K, V, S> BaseCache<K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    pub fn set_expiration_clock(&self, clock: Option<Clock>) {
         self.inner.set_expiration_clock(clock);
     }
 }
@@ -1277,7 +1285,7 @@ where
 //
 // for testing
 //
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 impl<K, V, S> Inner<K, V, S>
 where
     K: Hash + Eq,

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -1,4 +1,6 @@
 use super::Cache;
+use crate::sync::EvictionHandler;
+
 use crate::{common::builder_utils, common::concurrent::Weigher};
 
 use std::{
@@ -47,6 +49,7 @@ pub struct CacheBuilder<K, V, C> {
     time_to_live: Option<Duration>,
     time_to_idle: Option<Duration>,
     cache_type: PhantomData<C>,
+    eviction_handler: Option<Box<dyn EvictionHandler<K, V>>>,
 }
 
 impl<K, V> Default for CacheBuilder<K, V, Cache<K, V, RandomState>>
@@ -62,6 +65,7 @@ where
             time_to_live: None,
             time_to_idle: None,
             cache_type: Default::default(),
+            eviction_handler: None,
         }
     }
 }
@@ -100,6 +104,7 @@ where
             self.weigher,
             self.time_to_live,
             self.time_to_idle,
+            self.eviction_handler,
         )
     }
 
@@ -125,6 +130,7 @@ where
             self.weigher,
             self.time_to_live,
             self.time_to_idle,
+            self.eviction_handler,
         )
     }
 }
@@ -170,6 +176,14 @@ impl<K, V, C> CacheBuilder<K, V, C> {
     pub fn time_to_live(self, duration: Duration) -> Self {
         Self {
             time_to_live: Some(duration),
+            ..self
+        }
+    }
+
+    /// Sets the eviction handler
+    pub fn eviction_handler(self, eviction_handler: Box<dyn EvictionHandler<K, V>>) -> Self {
+        Self {
+            eviction_handler: Some(eviction_handler),
             ..self
         }
     }

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -1241,9 +1241,11 @@ mod tests {
             .time_to_live(Duration::from_millis(250))
             .eviction_handler(handler)
             .build();
+        let (clock, mock) = Clock::mock();
+        cache.set_expiration_clock(Some(clock));
 
         cache.insert("Foo".to_owned(), "Bar".to_owned());
-        std::thread::sleep(Duration::from_millis(250));
+        mock.increment(Duration::from_millis(250));
         cache.sync();
         let keys = removed_keys.lock().unwrap();
         assert_eq!(keys.len(), 1);
@@ -1258,9 +1260,10 @@ mod tests {
             .time_to_idle(Duration::from_millis(250))
             .eviction_handler(handler)
             .build();
-
+        let (clock, mock) = Clock::mock();
+        cache.set_expiration_clock(Some(clock));
         cache.insert("Foo".to_owned(), "Bar".to_owned());
-        std::thread::sleep(Duration::from_millis(250));
+        mock.increment(Duration::from_millis(250));
         cache.sync();
         let keys = removed_keys.lock().unwrap();
         assert_eq!(keys.len(), 1);
@@ -1275,9 +1278,11 @@ mod tests {
             .time_to_live(Duration::from_millis(250))
             .eviction_handler(handler)
             .build();
-
+        let (clock, mock) = Clock::mock();
+        cache.set_expiration_clock(Some(clock));
         cache.insert("Foo".to_owned(), "Bar".to_owned());
-        std::thread::sleep(Duration::from_millis(250));
+
+        mock.increment(Duration::from_millis(250));
         let res = cache.get(&"Foo".to_owned());
         assert!(res.is_none());
         let keys = removed_keys.lock().unwrap();

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -646,12 +646,19 @@ where
     pub(crate) fn reconfigure_for_testing(&mut self) {
         self.base.reconfigure_for_testing();
     }
+}
 
-    pub(crate) fn set_expiration_clock(&self, clock: Option<crate::common::time::Clock>) {
+#[cfg(any(test, feature = "testing"))]
+impl<K, V, S> Cache<K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    pub fn set_expiration_clock(&self, clock: Option<crate::common::time::Clock>) {
         self.base.set_expiration_clock(clock);
     }
 }
-
 pub(crate) struct DefaultEvictionHandler<K, V> {
     pk: PhantomData<K>,
     pv: PhantomData<V>,


### PR DESCRIPTION
This PR does two things.

1. Adds an `upsert` method to the `sync` cache.
2. Enables a `testing` feature for easier testing of applications using `mini-moka`. This exposes test functions for working with the test clock.
3. Adds an eviction handler function to the cache that can be used to perform tasks on eviction. e.g.
```rust
        let removed_keys = Arc::new(Mutex::new(Vec::new()));
        let rk = removed_keys.clone();
        let cache: Cache<String, String> = Cache::builder()
            .time_to_live(Duration::from_millis(250))
            .eviction_handler(move |key: Arc<String>, _, cause| {
                rk.lock().unwrap().push(((*key).clone(), cause));
            })
            .build();
``` 

I'm happy to split these in two, squash the commits, or make any additional changes if these changes are something the project might want to accept.