### PR TITLE
Fix The CI for MSRV 1.61.0

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -5,3 +5,4 @@ set -eux
 # Pin some dependencies to specific versions for the MSRV.
 cargo update -p dashmap --precise 5.4.0
 cargo update -p tempfile --precise 3.6.0
+cargo update -p cargo-platform --precise 0.1.5

--- a/.github/workflows/Audit.yml
+++ b/.github/workflows/Audit.yml
@@ -13,22 +13,15 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Moka
-        uses: actions/checkout@v2
+      - name: Checkout Mini Moka
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain (Nightly)
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly
-          override: true
 
-      - uses: Swatinem/rust-cache@v1
-
-      - name: cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
+      - run: cargo clean
 
       - name: Check for known security vulnerabilities (Latest versions)
         uses: actions-rs/audit-check@v1
@@ -36,10 +29,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Downgrade dependencies to minimal versions
-        uses: actions-rs/cargo@v1
-        with:
-          command: update
-          args: -Z minimal-versions
+        run: cargo update -Z minimal-versions
 
       - name: Check for known security vulnerabilities (Minimal versions)
         uses: actions-rs/audit-check@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable
@@ -28,47 +29,28 @@ jobs:
 
     steps:
       - name: Checkout Mini Moka
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v1
-
-      - name: cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
+      - run: cargo clean
 
       - name: Downgrade dependencies to minimal versions (Nightly only)
-        uses: actions-rs/cargo@v1
         if: ${{ matrix.rust == 'nightly' }}
-        with:
-          command: update
-          args: -Z minimal-versions
+        run: cargo update -Z minimal-versions
 
       - name: Pin some dependencies to specific versions (MSRV only)
         if: ${{ matrix.rust == '1.61.0' }}
         run: ./.ci_extras/pin-crate-vers-msrv.sh
 
       - name: Show cargo tree
-        uses: actions-rs/cargo@v1
-        with:
-          command: tree
+        run: cargo tree
 
       - name: Run tests (debug, sync feature)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features sync
+        run: cargo test --features sync
 
       - name: Run tests (release, sync feature)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features sync
+        run: cargo test --release --features sync

--- a/.github/workflows/Lints.yml
+++ b/.github/workflows/Lints.yml
@@ -21,23 +21,16 @@ jobs:
             rustflags: '--cfg beta_clippy'
 
     steps:
-      - name: Checkout Moka
-        uses: actions/checkout@v2
+      - name: Checkout Mini Moka
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust.toolchain }}
-          override: true
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v1
-
-      - name: cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
+      - run: cargo clean
 
       - name: Run Clippy
         uses: actions-rs/clippy-check@v1
@@ -48,8 +41,5 @@ jobs:
           RUSTFLAGS: ${{ matrix.rust.rustflags }}
 
       - name: Run Rustfmt
-        uses: actions-rs/cargo@v1
         if: ${{ matrix.rust.toolchain == 'stable' }}
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check

--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -21,42 +21,47 @@ jobs:
   linux-cross:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         platform:
           - target: aarch64-unknown-linux-musl
+            rust-version: stable
           - target: i686-unknown-linux-musl
+            rust-version: stable
           - target: armv7-unknown-linux-musleabihf
+            rust-version: stable
           - target: armv5te-unknown-linux-musleabi
+            rust-version: stable
           - target: mips-unknown-linux-musl
+            rust-version: "1.72.1"
+            cargo-version: "+1.72.1"
           - target: mipsel-unknown-linux-musl
+            rust-version: "1.72.1"
+            cargo-version: "+1.72.1"
 
     steps:
-      - name: Checkout Moka
-        uses: actions/checkout@v2
+      - name: Checkout Mini Moka
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: stable
-          target: ${{ matrix.platform.target }}
-          override: true
+          toolchain: ${{ matrix.platform.rust-version }}
+          targets: ${{ matrix.platform.target }}
+
+      - name: Install cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
 
       - name: Remove integration tests and force enable rustc_version crate
         run: |
           rm -rf tests
           sed -i '/actix-rt\|async-std\|reqwest\|skeptic/d' Cargo.toml
 
-      - uses: Swatinem/rust-cache@v1
-
-      - name: cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
+      - run: cargo clean
 
       - name: Run tests (sync feature)
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: test
-          args: --release --features sync --target ${{ matrix.platform.target }}
+        run: |
+          cross ${{ matrix.platform.carge-version }} test --release -F sync \
+            --target ${{ matrix.platform.target }}

--- a/.github/workflows/Miri.yml
+++ b/.github/workflows/Miri.yml
@@ -22,26 +22,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Moka
-        uses: actions/checkout@v2
+      - name: Checkout Mini Moka
+        uses: actions/checkout@v4
 
       - name: Install Rust nightly toolchain with Miri
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly
-          override: true
           components: miri
 
-      - uses: Swatinem/rust-cache@v1
-
-      - name: cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
+      - run: cargo clean
 
       - name: Run Miri test (deque)
-        uses: actions-rs/cargo@v1
-        with:
-          command: miri
-          args: test deque
+        run: cargo miri test deque

--- a/.github/workflows/Skeptic.yml
+++ b/.github/workflows/Skeptic.yml
@@ -20,37 +20,23 @@ jobs:
           - beta
 
     steps:
-      - name: Checkout Moka
-        uses: actions/checkout@v2
+      - name: Checkout Mini Moka
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v1
-
-      - name: cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
+      - run: cargo clean
 
       - name: Run tests (no features)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release
+        run: cargo test --release
         env:
           RUSTFLAGS: '--cfg skeptic'
 
       - name: Run compile error tests (sync feature, trybuild)
-        uses: actions-rs/cargo@v1
         if: ${{ matrix.rust == 'stable' }}
-        with:
-          command: test
-          args: ui_trybuild --release --features 'sync'
+        run: cargo test ui_trybuild --release --features sync
         env:
           RUSTFLAGS: '--cfg trybuild'

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 - 2022 Tatsuya Kawano
+   Copyright 2020 - 2024 Tatsuya Kawano
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 - 2022 Tatsuya Kawano
+Copyright (c) 2020 - 2024 Tatsuya Kawano
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- Fix a compile error on the MSRV 1.61.1 by pining `cargo-platform` crate to v0.1.5.
- Fix that `rustup` cannot install the MIPS targets for Rust 1.75.0 by pinning the Rust version for these targets to 1.72.1 for now.
    - For more details, see: https://github.com/moka-rs/moka/issues/333
- Update the copyright year in the license files.