### PR TITLE
 Fix occasional panic in `FrequencySketch` in debug build

### DIFF
--- a/.github/workflows/Kani.yml
+++ b/.github/workflows/Kani.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Moka
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Show CPU into
         run: |

--- a/.github/workflows/Kani.yml
+++ b/.github/workflows/Kani.yml
@@ -1,0 +1,28 @@
+name: Kani CI
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.vscode/**'
+      - CHANGELOG.md
+      - README.md
+  push:
+    paths-ignore:
+      - '.vscode/**'
+      - CHANGELOG.md
+      - README.md
+
+jobs:
+  run-kani:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Moka
+        uses: actions/checkout@v3
+
+      - name: Show CPU into
+        run: |
+          nproc
+          lscpu
+          free -m
+      - name: Run Kani
+        uses: model-checking/kani-github-action@v1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Mini Moka Cache &mdash; Change Log
 
+## Version 0.10.3
+
+### Fixed
+
+- Fixed occasional panic in internal `FrequencySketch` in debug build.
+  ([#21][gh-issue-0021])
+
+
 ## Version 0.10.2
 
 ### Fixed
@@ -52,6 +60,8 @@ lightweight.
 
 <!-- Links -->
 [moka-v0.9.6]: https://github.com/moka-rs/moka/tree/v0.9.6
+
+[gh-issue-0021]: https://github.com/moka-rs/mini-moka/issues/21/
 
 [gh-pull-0015]: https://github.com/moka-rs/mini-moka/pull/15/
 [gh-pull-0006]: https://github.com/moka-rs/mini-moka/pull/6/

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -323,3 +323,73 @@ mod tests {
         }
     }
 }
+
+// Verify that some properties hold such as no panic occurs on any possible inputs.
+#[cfg(kani)]
+mod kani {
+    use super::FrequencySketch;
+
+    const CAPACITIES: &[u32] = &[
+        0,
+        1,
+        1024,
+        1025,
+        2u32.pow(24),
+        2u32.pow(24) + 1,
+        2u32.pow(30),
+        2u32.pow(30) + 1,
+        u32::MAX,
+    ];
+
+    #[kani::proof]
+    fn verify_ensure_capacity() {
+        // Check for arbitrary capacities.
+        let capacity = kani::any();
+        let mut sketch = FrequencySketch::default();
+        sketch.ensure_capacity(capacity);
+    }
+
+    #[kani::proof]
+    fn verify_frequency() {
+        // Check for some selected capacities.
+        for capacity in CAPACITIES {
+            let mut sketch = FrequencySketch::default();
+            sketch.ensure_capacity(*capacity);
+
+            // Check for arbitrary hashes.
+            let hash = kani::any();
+            let frequency = sketch.frequency(hash);
+            assert!(frequency <= 15);
+        }
+    }
+
+    #[kani::proof]
+    fn verify_increment() {
+        // Only check for small capacities. Because Kani Rust Verifier is a model
+        // checking tool, it will take much longer time (exponential) to check larger
+        // capacities here.
+        for capacity in &[0, 1, 128] {
+            let mut sketch = FrequencySketch::default();
+            sketch.ensure_capacity(*capacity);
+
+            // Check for arbitrary hashes.
+            let hash = kani::any();
+            sketch.increment(hash);
+        }
+    }
+
+    #[kani::proof]
+    fn verify_index_of() {
+        // Check for arbitrary capacities.
+        let capacity = kani::any();
+        let mut sketch = FrequencySketch::default();
+        sketch.ensure_capacity(capacity);
+
+        // Check for arbitrary hashes.
+        let hash = kani::any();
+        for i in 0..4 {
+            let index = sketch.index_of(hash, i);
+            assert!(index < sketch.table.len());
+        }
+    }
+}

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -180,7 +180,7 @@ impl FrequencySketch {
     fn index_of(&self, hash: u64, depth: u8) -> usize {
         let i = depth as usize;
         let mut hash = hash.wrapping_add(SEED[i]).wrapping_mul(SEED[i]);
-        hash += hash >> 32;
+        hash = hash.wrapping_add(hash >> 32);
         (hash & self.table_mask) as usize
     }
 }


### PR DESCRIPTION
Fixes #21.

This PR is a port of https://github.com/moka-rs/moka/pull/272 and prevents an internal `index_of` method of `FrequencySketch` from panicking by arithmetic overflow.

- Only debug build was affected by this issue.
- Release build was not affected unless overflow checks were explicitly enabled at the build time.

## Changes

- Replace an `u64` addition (`+`) operator in `FrequencySketch::index_of` method with `wrapping_add` method.
    - Wrapping (modular) addition is the desired behavior for `index_of` method.
    - The `+` operator will behave the same to `wrapping _add` method in release build (where overflow checks are disabled).
- Add test harnesses (test cases) for [Kani Verifier](https://github.com/model-checking/kani) to ensure there is no chance for arithmetic overflows and other panics to occur in `FrequencySketch` (not only for `index_of` method but also other methods).
    - Enable a CI job to run Kani test on every git pushes.

## Verification

- [x] Ran `cargo kani` _before_ fixing the issue, and arithmetic overflow was detected.
- [x] Ran `cargo kani` _after_ fixing, and no issue was detected.