### PR TITLE
CI: Fix the CI (remove Skeptic etc.)

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -4,5 +4,3 @@ set -eux
 
 # Pin some dependencies to specific versions for the MSRV.
 cargo update -p dashmap --precise 5.4.0
-cargo update -p tempfile --precise 3.6.0
-cargo update -p cargo-platform --precise 0.1.5

--- a/.github/workflows/Lints.yml
+++ b/.github/workflows/Lints.yml
@@ -33,10 +33,7 @@ jobs:
       - run: cargo clean
 
       - name: Run Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --lib --tests --all-features --all-targets -- -D warnings
+        run: cargo clippy --lib --tests --all-features --all-targets -- -D warnings
         env:
           RUSTFLAGS: ${{ matrix.rust.rustflags }}
 

--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Remove integration tests and force enable rustc_version crate
         run: |
           rm -rf tests
-          sed -i '/actix-rt\|async-std\|reqwest\|skeptic/d' Cargo.toml
+          sed -i '/actix-rt\|async-std\|reqwest/d' Cargo.toml
 
       - run: cargo clean
 

--- a/.github/workflows/Trybuild.yml
+++ b/.github/workflows/Trybuild.yml
@@ -1,4 +1,4 @@
-name: Skeptic and Trybuild
+name: Trybuild
 
 on:
   push:
@@ -27,13 +27,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-
-      - run: cargo clean
-
-      - name: Run tests (no features)
-        run: cargo test --release
-        env:
-          RUSTFLAGS: '--cfg skeptic'
 
       - name: Run compile error tests (sync feature, trybuild)
         if: ${{ matrix.rust == 'stable' }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,8 @@
         "Deques",
         "devcontainer",
         "docsrs",
+        "doctest",
+        "doctests",
         "Einziger",
         "else's",
         "Eytan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["cache", "concurrent"]
 categories = ["caching", "concurrency"]
 readme = "README.md"
 exclude = [".circleci", ".devcontainer", ".github", ".gitpod.yml", ".vscode"]
-build = "build.rs"
 
 [features]
 default = ["sync"]
@@ -39,13 +38,9 @@ dashmap = { version = "5.2", optional = true }
 anyhow = "1.0.19"
 getrandom = "0.2"
 once_cell = "1.7"
-skeptic = "0.13"
 
 [target.'cfg(trybuild)'.dev-dependencies]
 trybuild = "1.0"
-
-[target.'cfg(skeptic)'.build-dependencies]
-skeptic = "0.13.5"
 
 # https://docs.rs/about/metadata
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ MSRV is _not_ considered a semver-breaking change.
 To run all tests including doc tests on the README, use the following command:
 
 ```console
-$ RUSTFLAGS='--cfg skeptic --cfg trybuild' cargo test --all-features
+$ RUSTFLAGS='--cfg trybuild' cargo test --all-features
 ```
 
 

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,0 @@
-#[cfg(skeptic)]
-fn main() {
-    // generates doc tests for `README.md`.
-    skeptic::generate_doc_tests(&["README.md"]);
-}
-
-#[cfg(not(any(skeptic)))]
-fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,3 +77,10 @@ mod tests {
         t.compile_fail("tests/compile_tests/sync/clone/*.rs");
     }
 }
+
+#[cfg(all(doctest, feature = "sync"))]
+mod doctests {
+    // https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#include-items-only-when-collecting-doctests
+    #[doc = include_str!("../README.md")]
+    struct ReadMeDoctests;
+}

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -57,7 +57,7 @@ impl<K, V, S> Clone for BaseCache<K, V, S> {
             inner: Arc::clone(&self.inner),
             read_op_ch: self.read_op_ch.clone(),
             write_op_ch: self.write_op_ch.clone(),
-            housekeeper: self.housekeeper.as_ref().map(Arc::clone),
+            housekeeper: self.housekeeper.clone(),
         }
     }
 }

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -956,6 +956,9 @@ where
                     break;
                 }
 
+                // clippy::map_clone will give us a false positive warning here.
+                // Version: clippy 0.1.77 (f2048098a1c 2024-02-09) in Rust 1.77.0-beta.2
+                #[allow(clippy::map_clone)]
                 let key = probation
                     .peek_front()
                     .map(|node| Rc::clone(&node.element.key));


### PR DESCRIPTION
- Update the doc tests on the `README.md` by replacing Skeptic with a regular `cargo test` command.
- Rename a CI job `Skeptic` to `Trybuild`.
- Fix beta Clippy warnings.
  - `clippy 0.1.77 (f2048098a1c 2024-02-09)`
- Fix the CI for the MSRV 1.61.0 by removing `cargo update` for `tempfile` and `cargo-platform`.
- Replace `actions-rs/clippy-check` with a regular GHA `run` command.
