### PR TITLE
Pin `triomphe` to keep the MSRV 1.61

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ tagptr = "0.2"
 
 # Opt-out serde and stable_deref_trait features
 # https://github.com/Manishearth/triomphe/pull/5
-triomphe = { version = "0.1.3", default-features = false }
+# 0.1.12 requires Rust 1.76
+triomphe = { version = ">=0.1.3, <0.1.12", default-features = false }
 
 # Optional dependencies (enabled by default)
 dashmap = { version = "5.2", optional = true }

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -117,7 +117,7 @@ impl FrequencySketch {
         }
 
         let start = ((hash & 3) << 2) as u8;
-        let mut frequency = std::u8::MAX;
+        let mut frequency = u8::MAX;
         for i in 0..4 {
             let index = self.index_of(hash, i);
             let count = (self.table[index] >> ((start + i) << 2) & 0xF) as u8;
@@ -252,7 +252,7 @@ mod tests {
         let mut sketch = FrequencySketch::default();
         sketch.ensure_capacity(512);
         let mut indexes = std::collections::HashSet::new();
-        let hashes = [std::u64::MAX, 0, 1];
+        let hashes = [u64::MAX, 0, 1];
         for hash in hashes.iter() {
             for depth in 0..4 {
                 indexes.insert(sketch.index_of(*hash, depth));


### PR DESCRIPTION
Pin `triomphe` crate to keep the MSRV 1.61. `triomphe@v0.1.12` requires Rust 1.76.