### PR TITLE
CI: codecov.io - Measure the code coverage with `cargo-llvm-cov` and upload the report to codecov.io

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,13 @@
+# https://docs.codecov.com/docs/quick-start#tips-and-tricks
+# https://docs.codecov.com/docs/codecovyml-reference
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch: false
+
+comment:
+  layout: "diff"
+  require_changes: true

--- a/.github/workflows/Codecov.yml
+++ b/.github/workflows/Codecov.yml
@@ -1,0 +1,39 @@
+name: Codecov
+
+on:
+  pull_request:
+    paths-ignore:
+    - '.devcontainer/**'
+    - '.gitpod.yml'
+    - '.vscode/**'
+
+jobs:
+  codecov:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Mini Moka
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - run: cargo clean
+
+      - name: Show cargo tree
+        run: cargo tree
+
+      - name: Run tests (debug, sync feature)
+        run: cargo llvm-cov --features sync --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          files: ./lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Actions job called "Codecov", which does the followings:

- Measure the code coverage on `cargo test`s with `cargo-llvm-cov`.
- Upload the report to codecov.io.
