### PR TITLE
Fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,12 @@ trybuild = "1.0"
 # Build the doc with some features enabled.
 features = []
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    "cfg(kani)",
+    "cfg(skeptic)",
+    "cfg(circleci)",
+    "cfg(trybuild)",
+    "cfg(beta_clippy)",
+] }

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -17,7 +17,7 @@
 #[derive(Default)]
 pub(crate) struct FrequencySketch {
     sample_size: u32,
-    table_mask: u64,
+    table_mask: u32,
     table: Box<[u64]>,
     size: u32,
 }
@@ -101,7 +101,7 @@ impl FrequencySketch {
         }
 
         self.table = vec![0; table_size as usize].into_boxed_slice();
-        self.table_mask = 0.max(table_size - 1) as u64;
+        self.table_mask = table_size - 1;
         self.sample_size = if cap == 0 {
             10
         } else {
@@ -181,7 +181,7 @@ impl FrequencySketch {
         let i = depth as usize;
         let mut hash = hash.wrapping_add(SEED[i]).wrapping_mul(SEED[i]);
         hash = hash.wrapping_add(hash >> 32);
-        (hash & self.table_mask) as usize
+        (hash & (self.table_mask as u64)) as usize
     }
 }
 


### PR DESCRIPTION
I also took the liberty to reduce the size of `table_mask` to `u32` as it's originally `u32` anyway.