### PR TITLE
[sync] Update to DashMap 6 (for mini-moka v0.11.x)

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -eux
-
-# Pin some dependencies to specific versions for the MSRV.
-cargo update -p dashmap --precise 5.4.0

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.61.0  # MSRV
+          - 1.76.0  # MSRV
           - nightly # For checking minimum version dependencies.
 
     steps:
@@ -41,10 +41,6 @@ jobs:
       - name: Downgrade dependencies to minimal versions (Nightly only)
         if: ${{ matrix.rust == 'nightly' }}
         run: cargo update -Z minimal-versions
-
-      - name: Pin some dependencies to specific versions (MSRV only)
-        if: ${{ matrix.rust == '1.61.0' }}
-        run: ./.ci_extras/pin-crate-vers-msrv.sh
 
       - name: Show cargo tree
         run: cargo tree

--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -32,12 +32,6 @@ jobs:
             rust-version: stable
           - target: armv5te-unknown-linux-musleabi
             rust-version: stable
-          - target: mips-unknown-linux-musl
-            rust-version: "1.76"
-            cargo-version: "+1.76"
-          - target: mipsel-unknown-linux-musl
-            rust-version: "1.76"
-            cargo-version: "+1.76"
 
     steps:
       - name: Checkout Mini Moka

--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -3,19 +3,19 @@ name: Linux cross compile tests
 on:
   push:
     paths-ignore:
-    - '.devcontainer/**'
-    - '.gitpod.yml'
-    - '.vscode/**'
-    - 'tests/**'
+      - ".devcontainer/**"
+      - ".gitpod.yml"
+      - ".vscode/**"
+      - "tests/**"
   pull_request:
     paths-ignore:
-    - '.devcontainer/**'
-    - '.gitpod.yml'
-    - '.vscode/**'
-    - 'tests/**'
+      - ".devcontainer/**"
+      - ".gitpod.yml"
+      - ".vscode/**"
+      - "tests/**"
   schedule:
     # Run against the last commit on the default branch on Friday at 9pm (UTC?)
-    - cron:  '0 21 * * 5'
+    - cron: "0 21 * * 5"
 
 jobs:
   linux-cross:
@@ -33,11 +33,11 @@ jobs:
           - target: armv5te-unknown-linux-musleabi
             rust-version: stable
           - target: mips-unknown-linux-musl
-            rust-version: "1.72.1"
-            cargo-version: "+1.72.1"
+            rust-version: "1.76"
+            cargo-version: "+1.76"
           - target: mipsel-unknown-linux-musl
-            rust-version: "1.72.1"
-            cargo-version: "+1.72.1"
+            rust-version: "1.76"
+            cargo-version: "+1.76"
 
     steps:
       - name: Checkout Mini Moka

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tagptr = "0.2"
 triomphe = { version = ">=0.1.3, <0.1.12", default-features = false }
 
 # Optional dependencies (enabled by default)
-dashmap = { version = "5.2", optional = true }
+dashmap = { version = "6.1", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mini-moka"
-version = "0.10.3"
+version = "0.11.0"
 edition = "2018"
 rust-version = "1.76"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mini-moka"
 version = "0.10.3"
 edition = "2018"
-rust-version = "1.61"
+rust-version = "1.76"
 
 description = "A lighter edition of Moka, a fast and concurrent cache library"
 license = "MIT OR Apache-2.0"
@@ -27,8 +27,7 @@ tagptr = "0.2"
 
 # Opt-out serde and stable_deref_trait features
 # https://github.com/Manishearth/triomphe/pull/5
-# 0.1.12 requires Rust 1.76
-triomphe = { version = ">=0.1.3, <0.1.12", default-features = false }
+triomphe = { version = "0.1.13", default-features = false }
 
 # Optional dependencies (enabled by default)
 dashmap = { version = "6.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Mini Moka's minimum supported Rust versions (MSRV) are the followings:
 
 | Feature          | MSRV                       |
 |:-----------------|:--------------------------:|
-| default features | Rust 1.61.0 (May 19, 2022) |
+| default features | Rust 1.76.0 (Feb 8, 2024)  |
 
 It will keep a rolling MSRV policy of at least 6 months. If only the default features
 are enabled, MSRV will be updated conservatively. When using other features, MSRV

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -201,7 +201,7 @@ impl FrequencySketch {
 mod tests {
     use super::FrequencySketch;
     use once_cell::sync::Lazy;
-    use std::hash::{BuildHasher, Hash, Hasher};
+    use std::hash::{BuildHasher, Hash};
 
     static ITEM: Lazy<u32> = Lazy::new(|| {
         let mut buf = [0; 4];
@@ -316,11 +316,7 @@ mod tests {
 
     fn hasher<K: Hash>() -> impl Fn(K) -> u64 {
         let build_hasher = std::collections::hash_map::RandomState::default();
-        move |key| {
-            let mut hasher = build_hasher.build_hasher();
-            key.hash(&mut hasher);
-            hasher.finish()
-        }
+        move |key| build_hasher.hash_one(&key)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //!
 //! | Feature          | MSRV                       |
 //! |:-----------------|:--------------------------:|
-//! | default features | Rust 1.61.0 (May 19, 2022) |
+//! | default features | Rust 1.76.0 (Feb 8, 2024) |
 //!
 //! If only the default features are enabled, MSRV will be updated conservatively.
 //! When using other features, MSRV might be updated more frequently, up to the

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -28,7 +28,7 @@ use smallvec::SmallVec;
 use std::{
     borrow::Borrow,
     collections::hash_map::RandomState,
-    hash::{BuildHasher, Hash, Hasher},
+    hash::{BuildHasher, Hash},
     ptr::NonNull,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -523,9 +523,7 @@ where
         Arc<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let mut hasher = self.build_hasher.build_hasher();
-        key.hash(&mut hasher);
-        hasher.finish()
+        self.build_hasher.hash_one(key)
     }
 
     #[inline]

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -450,7 +450,7 @@ enum AdmissionResult<K> {
 
 type CacheStore<K, V, S> = dashmap::DashMap<Arc<K>, TrioArc<ValueEntry<K, V>>, S>;
 
-type CacheEntryRef<'a, K, V, S> = DashMapRef<'a, Arc<K>, TrioArc<ValueEntry<K, V>>, S>;
+type CacheEntryRef<'a, K, V> = DashMapRef<'a, Arc<K>, TrioArc<ValueEntry<K, V>>>;
 
 pub(crate) struct Inner<K, V, S> {
     max_capacity: Option<u64>,
@@ -529,7 +529,7 @@ where
     }
 
     #[inline]
-    fn get<Q>(&self, key: &Q) -> Option<CacheEntryRef<'_, K, V, S>>
+    fn get<Q>(&self, key: &Q) -> Option<CacheEntryRef<'_, K, V>>
     where
         Arc<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -554,7 +554,7 @@ where
     V: 'a,
     S: BuildHasher + Clone,
 {
-    type Item = EntryRef<'a, K, V, S>;
+    type Item = EntryRef<'a, K, V>;
 
     type IntoIter = Iter<'a, K, V, S>;
 

--- a/src/sync/iter.rs
+++ b/src/sync/iter.rs
@@ -26,7 +26,7 @@ where
     K: Eq + Hash,
     S: BuildHasher + Clone,
 {
-    type Item = EntryRef<'a, K, V, S>;
+    type Item = EntryRef<'a, K, V>;
 
     fn next(&mut self) -> Option<Self::Item> {
         for map_ref in &mut self.map_iter {

--- a/src/sync/mapref.rs
+++ b/src/sync/mapref.rs
@@ -1,30 +1,25 @@
 use crate::common::concurrent::ValueEntry;
 
-use std::{
-    hash::{BuildHasher, Hash},
-    sync::Arc,
-};
+use std::{hash::Hash, sync::Arc};
 use triomphe::Arc as TrioArc;
 
-type DashMapRef<'a, K, V, S> =
-    dashmap::mapref::multiple::RefMulti<'a, Arc<K>, TrioArc<ValueEntry<K, V>>, S>;
+type DashMapRef<'a, K, V> =
+    dashmap::mapref::multiple::RefMulti<'a, Arc<K>, TrioArc<ValueEntry<K, V>>>;
 
-pub struct EntryRef<'a, K, V, S>(DashMapRef<'a, K, V, S>);
+pub struct EntryRef<'a, K, V>(DashMapRef<'a, K, V>);
 
-unsafe impl<'a, K, V, S> Sync for EntryRef<'a, K, V, S>
+unsafe impl<'a, K, V> Sync for EntryRef<'a, K, V>
 where
     K: Eq + Hash + Send + Sync,
     V: Send + Sync,
-    S: BuildHasher,
 {
 }
 
-impl<'a, K, V, S> EntryRef<'a, K, V, S>
+impl<'a, K, V> EntryRef<'a, K, V>
 where
     K: Eq + Hash,
-    S: BuildHasher + Clone,
 {
-    pub(crate) fn new(map_ref: DashMapRef<'a, K, V, S>) -> Self {
+    pub(crate) fn new(map_ref: DashMapRef<'a, K, V>) -> Self {
         Self(map_ref)
     }
 
@@ -41,10 +36,9 @@ where
     }
 }
 
-impl<'a, K, V, S> std::ops::Deref for EntryRef<'a, K, V, S>
+impl<'a, K, V> std::ops::Deref for EntryRef<'a, K, V>
 where
     K: Eq + Hash,
-    S: BuildHasher + Clone,
 {
     type Target = V;
 

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -17,7 +17,7 @@ use std::{
     borrow::Borrow,
     collections::{hash_map::RandomState, HashMap},
     fmt,
-    hash::{BuildHasher, Hash, Hasher},
+    hash::{BuildHasher, Hash},
     ptr::NonNull,
     rc::Rc,
     time::Duration,
@@ -500,9 +500,7 @@ where
         Rc<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let mut hasher = self.build_hasher.build_hasher();
-        key.hash(&mut hasher);
-        hasher.finish()
+        self.build_hasher.hash_one(key)
     }
 
     #[inline]


### PR DESCRIPTION
- Cherry-pick from commit f85462916feca9600ae24540ba5699eb8cb6fefb for #34.
- Also bump the `mini-moka` version to `v0.11.0`.
- Fix Clippy warning for [manual_hash_one](https://rust-lang.github.io/rust-clippy/master/index.html#manual_hash_one) lint.
    - This list is enabled when `rust-version` in `Cargo.toml` is set to `1.75.0` or higher.

* * *
Fixes #38