### PR TITLE
CI: Pin Kani version to `v0.54.0` to avoid tests to stall

### DIFF
--- a/.github/workflows/Kani.yml
+++ b/.github/workflows/Kani.yml
@@ -26,3 +26,6 @@ jobs:
           free -m
       - name: Run Kani
         uses: model-checking/kani-github-action@v1.0
+        # Workaround for https://github.com/moka-rs/mini-moka/issues/36
+        with:
+          kani-version: '0.54.0'


### PR DESCRIPTION
This is a workaround for #36.