### PR TITLE
Implement TypeSize for Cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ exclude = [".circleci", ".devcontainer", ".github", ".gitpod.yml", ".vscode"]
 [features]
 default = ["sync"]
 
-sync = ["dashmap"]
+sync = ["dep:dashmap"]
+typesize = ["dep:typesize", "dashmap?/typesize"]
 
 [dependencies]
 crossbeam-channel = "0.5.5"
@@ -31,6 +32,10 @@ triomphe = { version = "0.1.13", default-features = false }
 
 # Optional dependencies (enabled by default)
 dashmap = { version = "6.1", optional = true }
+typesize = { version = "0.1.9", optional = true }
+
+[patch.crates-io.typesize]
+git = "https://github.com/GnomedDev/typesize"
 
 [dev-dependencies]
 anyhow = "1.0.19"

--- a/src/common.rs
+++ b/src/common.rs
@@ -7,6 +7,7 @@ pub(crate) mod builder_utils;
 pub(crate) mod deque;
 pub(crate) mod frequency_sketch;
 pub(crate) mod time;
+pub(crate) mod typesize_helpers;
 
 // Note: `CacheRegion` cannot have more than four enum variants. This is because
 // `crate::{sync,unsync}::DeqNodes` uses a `tagptr::TagNonNull<DeqNode<T>, 2>`

--- a/src/common/concurrent.rs
+++ b/src/common/concurrent.rs
@@ -13,6 +13,8 @@ pub(crate) mod atomic_time;
 
 use self::entry_info::EntryInfo;
 
+use super::typesize_helpers::MaybeOwnedArc;
+
 pub(crate) type Weigher<K, V> = Arc<dyn Fn(&K, &V) -> u32 + Send + Sync + 'static>;
 
 pub(crate) trait AccessTime {
@@ -60,8 +62,9 @@ impl<K> KeyDate<K> {
     }
 }
 
+#[cfg(feature = "typesize")]
 pub(crate) struct KeyHashDate<K> {
-    key: Arc<K>,
+    key: MaybeOwnedArc<K>,
     hash: u64,
     entry_info: TrioArc<EntryInfo<K>>,
 }

--- a/src/common/concurrent/atomic_time.rs
+++ b/src/common/concurrent/atomic_time.rs
@@ -2,6 +2,7 @@ use super::Instant;
 
 use std::sync::RwLock;
 
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 pub(crate) struct AtomicInstant {
     instant: RwLock<Option<Instant>>,
 }

--- a/src/common/concurrent/deques.rs
+++ b/src/common/concurrent/deques.rs
@@ -7,6 +7,8 @@ use crate::common::{
 use std::ptr::NonNull;
 use tagptr::TagNonNull;
 use triomphe::Arc as TrioArc;
+
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 pub(crate) struct Deques<K> {
     pub(crate) window: Deque<KeyHashDate<K>>, //    Not used yet.
     pub(crate) probation: Deque<KeyHashDate<K>>,

--- a/src/common/concurrent/housekeeper.rs
+++ b/src/common/concurrent/housekeeper.rs
@@ -18,6 +18,7 @@ pub(crate) trait InnerSync {
     fn now(&self) -> Instant;
 }
 
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 pub(crate) struct Housekeeper {
     is_sync_running: AtomicBool,
     sync_after: AtomicInstant,

--- a/src/common/deque.rs
+++ b/src/common/deque.rs
@@ -14,6 +14,8 @@
 
 use std::{marker::PhantomData, ptr::NonNull};
 
+use typesize::TypeSize;
+
 use super::CacheRegion;
 
 // `crate::{sync,unsync}::DeqNodes` uses a `tagptr::TagNonNull<DeqNode<T>, 2>`
@@ -326,6 +328,11 @@ impl<T> Deque<T> {
             }
         }
     }
+}
+
+#[cfg(feature = "typesize")]
+impl<T: TypeSize> typesize::TypeSize for Deque<T> {
+    // TODO: Implement extra_size properly
 }
 
 #[cfg(test)]

--- a/src/common/time.rs
+++ b/src/common/time.rs
@@ -6,6 +6,7 @@ pub(crate) use clock::Clock;
 
 /// a wrapper type over Instant to force checked additions and prevent
 /// unintentional overflow. The type preserve the Copy semantics for the wrapped
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(PartialEq, PartialOrd, Clone, Copy)]
 pub(crate) struct Instant(clock::Instant);
 

--- a/src/common/time/clock.rs
+++ b/src/common/time/clock.rs
@@ -6,18 +6,21 @@ use std::{
 #[cfg(test)]
 use std::time::Duration;
 
+use crate::common::typesize_helpers::MaybeOwnedArc;
+
 pub(crate) type Instant = StdInstant;
 
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 pub(crate) struct Clock {
-    mock: Option<Arc<Mock>>,
+    mock: Option<MaybeOwnedArc<Mock>>,
 }
 
 impl Clock {
     #[cfg(test)]
-    pub(crate) fn mock() -> (Clock, Arc<Mock>) {
-        let mock = Arc::new(Mock::default());
+    pub(crate) fn mock() -> (Clock, MaybeOwnedArc<Mock>) {
+        let mock = MaybeOwnedArc::new(Mock::default());
         let clock = Clock {
-            mock: Some(Arc::clone(&mock)),
+            mock: Some(MaybeOwnedArc::clone(&mock)),
         };
         (clock, mock)
     }
@@ -31,6 +34,7 @@ impl Clock {
     }
 }
 
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 pub(crate) struct Mock {
     now: RwLock<Instant>,
 }

--- a/src/common/typesize_helpers.rs
+++ b/src/common/typesize_helpers.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+
+/// Wrapper around `SizableArc<T, Owned>`` with support for disabling typesize.
+///
+/// This denotes an Arc where T's size should be considered when calling `TypeSize::get_size`
+#[derive(Debug)]
+pub(crate) struct MaybeOwnedArc<T>(
+    #[cfg(feature = "typesize")] typesize::ptr::SizableArc<T, typesize::ptr::Owned>,
+    #[cfg(not(feature = "typesize"))] Arc<T>,
+);
+
+impl<T> MaybeOwnedArc<T> {
+    pub(crate) fn new(inner: T) -> Self {
+        Self(Arc::new(inner).into())
+    }
+
+    pub(crate) fn get_inner(self) -> Arc<T> {
+        #[cfg(feature = "typesize")]
+        let inner = self.0 .0;
+        #[cfg(not(feature = "typesize"))]
+        let inner = self.0;
+
+        inner
+    }
+}
+
+#[cfg(feature = "typesize")]
+impl<T: typesize::TypeSize> typesize::TypeSize for MaybeOwnedArc<T> {
+    fn extra_size(&self) -> usize {
+        self.0.extra_size()
+    }
+
+    typesize::if_typesize_details! {
+        fn get_collection_item_count(&self) -> Option<usize> {
+            self.0.get_collection_item_count()
+        }
+    }
+}
+
+impl<T> std::ops::Deref for MaybeOwnedArc<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> Clone for MaybeOwnedArc<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone().into())
+    }
+}


### PR DESCRIPTION
Draft as not completed, alongside some unreleased typesize features that will make implementing this less painful.

Closes #39 and closes #18.