### PR TITLE
 Add remove method to return `Option<V>` for unsync cache (`v0.11.x` branch)

### DIFF
--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -425,8 +425,7 @@ where
             crate::unsync::deques::Deques::unlink_wo(&mut self.deques.write_order, &mut entry);
             self.saturating_sub_from_total_weight(weight as u64);
             Some(entry.value)
-        }
-        else {
+        } else {
             None
         }
     }


### PR DESCRIPTION
On #43, @JokerXiL said:

> With current implementation of unsync cache, it is possible for the `invalidate` method to return previous cached value.
> 
> I modified it and put it as new `remove` method.

In order to merge the stuff for #43 into the current active branch `v0.11.x`, I created a new branch from `v0.11.x` branch and ran `git cherry-pick 7cad7fd44afd61a09df18b3c0b7bb4eb63e14faf` to take the commit.

