### PR TITLE
feat: add js feature and wasm support via web_time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [".circleci", ".devcontainer", ".github", ".gitpod.yml", ".vscode"]
 
 [features]
 default = ["sync"]
+js = ["dep:web-time"]
 
 sync = ["dashmap"]
 
@@ -24,6 +25,7 @@ crossbeam-channel = "0.5.5"
 crossbeam-utils = "0.8"
 smallvec = "1.8"
 tagptr = "0.2"
+web-time = { version = "1.1.0", optional = true }
 
 # Opt-out serde and stable_deref_trait features
 # https://github.com/Manishearth/triomphe/pull/5
@@ -36,6 +38,10 @@ dashmap = { version = "6.1", optional = true }
 anyhow = "1.0.19"
 getrandom = "0.2"
 once_cell = "1.7"
+wasm-bindgen-test = "0.3.50"
+
+[target.wasm32-unknown-unknown.dev-dependencies]
+getrandom = { version="0.2", features = ["js"] }
 
 [target.'cfg(trybuild)'.dev-dependencies]
 trybuild = "1.0"

--- a/src/common/time/clock.rs
+++ b/src/common/time/clock.rs
@@ -1,12 +1,13 @@
-use std::{
-    sync::{Arc, RwLock},
-    time::Instant as StdInstant,
-};
+use std::sync::{Arc, RwLock};
 
 #[cfg(test)]
 use std::time::Duration;
 
-pub(crate) type Instant = StdInstant;
+#[cfg(not(feature = "js"))]
+pub(crate) type Instant = std::time::Instant;
+
+#[cfg(feature = "js")]
+pub(crate) type Instant = web_time::Instant;
 
 pub(crate) struct Clock {
     mock: Option<Arc<Mock>>,
@@ -26,7 +27,7 @@ impl Clock {
         if let Some(mock) = &self.mock {
             *mock.now.read().expect("lock poisoned")
         } else {
-            StdInstant::now()
+            Instant::now()
         }
     }
 }
@@ -38,7 +39,7 @@ pub(crate) struct Mock {
 impl Default for Mock {
     fn default() -> Self {
         Self {
-            now: RwLock::new(StdInstant::now()),
+            now: RwLock::new(Instant::now()),
         }
     }
 }

--- a/src/unsync/builder.rs
+++ b/src/unsync/builder.rs
@@ -186,10 +186,11 @@ impl<K, V, C> CacheBuilder<K, V, C> {
 #[cfg(test)]
 mod tests {
     use super::CacheBuilder;
-
     use std::time::Duration;
+    use wasm_bindgen_test::wasm_bindgen_test;
 
     #[test]
+    #[wasm_bindgen_test]
     fn build_cache() {
         // Cache<char, String>
         let mut cache = CacheBuilder::new(100).build();
@@ -217,6 +218,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     #[should_panic(expected = "time_to_live is longer than 1000 years")]
     fn build_cache_too_long_ttl() {
         let thousand_years_secs: u64 = 1000 * 365 * 24 * 3600;
@@ -228,6 +230,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     #[should_panic(expected = "time_to_idle is longer than 1000 years")]
     fn build_cache_too_long_tti() {
         let thousand_years_secs: u64 = 1000 * 365 * 24 * 3600;

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -1066,12 +1066,15 @@ fn weigh<K, V>(weigher: &mut Option<Weigher<K, V>>, key: &K, value: &V) -> u32 {
 // To see the debug prints, run test as `cargo test -- --nocapture`
 #[cfg(test)]
 mod tests {
+    use wasm_bindgen_test::wasm_bindgen_test;
+
     use super::Cache;
     use crate::common::time::Clock;
 
     use std::time::Duration;
 
     #[test]
+    #[wasm_bindgen_test]
     fn basic_single_thread() {
         let mut cache = Cache::new(3);
         cache.enable_frequency_sketch_for_testing();
@@ -1122,6 +1125,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn size_aware_eviction() {
         let weigher = |_k: &&str, v: &(&str, u32)| v.1;
 
@@ -1207,6 +1211,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn invalidate_all() {
         let mut cache = Cache::new(100);
         cache.enable_frequency_sketch_for_testing();
@@ -1236,6 +1241,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn invalidate_entries_if() {
         use std::collections::HashSet;
 
@@ -1293,6 +1299,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn time_to_live() {
         let mut cache = Cache::builder()
             .max_capacity(100)
@@ -1346,6 +1353,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn time_to_idle() {
         let mut cache = Cache::builder()
             .max_capacity(100)
@@ -1397,6 +1405,7 @@ mod tests {
 
     #[cfg_attr(target_pointer_width = "16", ignore)]
     #[test]
+    #[wasm_bindgen_test]
     fn test_skt_capacity_will_not_overflow() {
         // power of two
         let pot = |exp| 2u64.pow(exp);
@@ -1442,6 +1451,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn test_debug_format() {
         let mut cache = Cache::new(10);
         cache.insert('a', "alice");


### PR DESCRIPTION
This adds experimental support for wasm/js using the [`web_time`](https://docs.rs/web-time/latest/web_time/) crate.

As wasm32-unknown-unknown does not directly support threads, I had problems getting `sync` to compile. So this currently just works for unsync.

A new feature `js` is introduced that enables the necessary dependencies. Tests need to be run with `wasm-pack`:

```bash
wasm-pack test --node --no-default-features --features js
```