### PR TITLE
chore: fix package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-mini_moka = "0.10"
+mini-moka = "0.10"
 ```
 
 


### PR DESCRIPTION
`mini_moka = "0.10"` -> `mini-moka = "0.10"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected package name format in the dependency example.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->