### PR TITLE
Fix a Clippy waring

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 - 2024 Tatsuya Kawano
+   Copyright 2020 - 2026 Tatsuya Kawano
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 - 2024 Tatsuya Kawano
+Copyright (c) 2020 - 2026 Tatsuya Kawano
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -207,7 +207,7 @@ mod tests {
     static ITEM: Lazy<u32> = Lazy::new(|| {
         let mut buf = [0; 4];
         getrandom::getrandom(&mut buf).unwrap();
-        unsafe { std::mem::transmute::<[u8; 4], u32>(buf) }
+        u32::from_ne_bytes(buf)
     });
 
     // This test was ported from Caffeine.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year to 2026 in Apache and MIT licenses.

* **Refactor**
  * Enhanced code safety by replacing unsafe operations with safer, endianness-preserving byte conversion methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->