### PR TITLE
fix(unsync): fix total weight tracking leak upon entry expiration in unsync Cache

### DIFF
--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -951,7 +951,7 @@ where
                 self.deques.unlink_ao(&mut entry);
                 Deques::unlink_wo(&mut self.deques.write_order, &mut entry);
                 evicted_entry_count += 1;
-                evicted_policy_weight = evicted_policy_weight.saturating_sub(weight as u64);
+                evicted_policy_weight = evicted_policy_weight.saturating_add(weight as u64);
             } else {
                 self.deques.write_order.pop_front();
             }
@@ -1439,6 +1439,25 @@ mod tests {
                 ensure_sketch_len(u64::MAX, pot30, "u64::MAX");
             }
         };
+    }
+
+    #[test]
+    fn test_ttl_weight_leak() {
+        let mut cache = Cache::builder()
+            .max_capacity(100)
+            .time_to_live(Duration::from_secs(10))
+            .build();
+
+        let (clock, mock) = Clock::mock();
+        cache.set_expiration_clock(Some(clock));
+
+        cache.insert("a", "alice");
+        assert_eq!(cache.weighted_size(), 1);
+
+        mock.increment(Duration::from_secs(10)); // 10 secs (expired).
+
+        assert_eq!(cache.get(&"a"), None);
+        assert_eq!(cache.weighted_size(), 0);
     }
 
     #[test]


### PR DESCRIPTION
- remove_expired_wo was most probably incorrectly using `saturating_sub`
- I have also added a test to check for the same. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cache weight accounting during TTL-based entry cleanup to prevent bookkeeping leaks and calculation errors when entries expire.

* **Tests**
  * Added unit test verifying that cache weight properly resets after TTL-expired entries are removed, ensuring accurate weight tracking across eviction cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->